### PR TITLE
3D block and entity icon

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,8 @@ dependencies {
     devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.7.29-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:harvestcraft:1.3.1-GTNH:dev')
-    compileOnly fileTree(dir: 'run/mods', include: ['blockrenderer*.jar'])
+    compileOnly('com.github.GTNewHorizons:BlockRenderer6343:1.3.12-pre:dev')
+//    compileOnly fileTree(dir: 'run/mods', include: ['blockrenderer*.jar'])
 
 //    api("com.github.GTNewHorizons:Angelica:1.0.0-beta39:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,6 +6,7 @@ dependencies {
     devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.7.29-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:harvestcraft:1.3.1-GTNH:dev')
+    compileOnly fileTree(dir: 'run/mods', include: ['blockrenderer*.jar'])
 
 //    api("com.github.GTNewHorizons:Angelica:1.0.0-beta39:dev")
 

--- a/src/main/java/com/gtnewhorizons/wdmla/api/Mods.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/api/Mods.java
@@ -20,7 +20,9 @@ public enum Mods {
     IGUANATWEAKS("IguanaTweaksTConstruct", null),
     TCONSTUCT("TConstruct", null),
     NOTENOUGHITEMS("NotEnoughItems", version -> new DefaultArtifactVersion("2.7.29-GTNH").compareTo(version) <= 0),
-    FORGEMULTIPARTS("ForgeMultipart", null);
+    FORGEMULTIPARTS("ForgeMultipart", null),
+    BLOCKRENDERER6343("blockrenderer6343", version -> new DefaultArtifactVersion("1.3.11").compareTo(version) <= 0)
+    ;
 
     public final String modID;
 

--- a/src/main/java/com/gtnewhorizons/wdmla/api/Mods.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/api/Mods.java
@@ -21,7 +21,7 @@ public enum Mods {
     TCONSTUCT("TConstruct", null),
     NOTENOUGHITEMS("NotEnoughItems", version -> new DefaultArtifactVersion("2.7.29-GTNH").compareTo(version) <= 0),
     FORGEMULTIPARTS("ForgeMultipart", null),
-    BLOCKRENDERER6343("blockrenderer6343", version -> new DefaultArtifactVersion("1.3.11").compareTo(version) <= 0)
+    BLOCKRENDERER6343("blockrenderer6343", version -> new DefaultArtifactVersion("1.3.12-pre").compareTo(version) <= 0)
     ;
 
     public final String modID;

--- a/src/main/java/com/gtnewhorizons/wdmla/config/PluginsConfig.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/config/PluginsConfig.java
@@ -43,6 +43,10 @@ public class PluginsConfig {
             @Config.LangKey("option.wdmla.core.show.modname")
             @Config.DefaultBoolean(true)
             public boolean showModName;
+
+            @Config.LangKey("option.wdmla.core.fancy.renderer")
+            @Config.DefaultBoolean(true)
+            public boolean fancyRenderer;
         }
 
         @Config.LangKey("provider.wdmla.core.default.entity")
@@ -59,6 +63,10 @@ public class PluginsConfig {
             @Config.LangKey("option.wdmla.core.show.modname")
             @Config.DefaultBoolean(true)
             public boolean showModName;
+
+            @Config.LangKey("option.wdmla.core.fancy.renderer")
+            @Config.DefaultBoolean(true)
+            public boolean fancyRenderer;
         }
     }
 

--- a/src/main/java/com/gtnewhorizons/wdmla/impl/ui/component/EntityComponent.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/impl/ui/component/EntityComponent.java
@@ -2,7 +2,7 @@ package com.gtnewhorizons.wdmla.impl.ui.component;
 
 import java.util.ArrayList;
 
-import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.Entity;
 
 import com.gtnewhorizons.wdmla.impl.ui.drawable.EntityDrawable;
 import com.gtnewhorizons.wdmla.impl.ui.sizer.Padding;
@@ -13,7 +13,7 @@ public class EntityComponent extends TooltipComponent {
     public static final int DEFAULT_W = 16;
     public static final int DEFAULT_H = 16;
 
-    public EntityComponent(EntityLiving entity) {
+    public EntityComponent(Entity entity) {
         super(new ArrayList<>(), new Padding(), new Size(DEFAULT_W, DEFAULT_H), new EntityDrawable(entity));
     }
 }

--- a/src/main/java/com/gtnewhorizons/wdmla/impl/ui/component/WorldBlockComponent.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/impl/ui/component/WorldBlockComponent.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizons.wdmla.impl.ui.component;
+
+import com.gtnewhorizons.wdmla.impl.ui.drawable.WorldBlockDrawable;
+import com.gtnewhorizons.wdmla.impl.ui.sizer.Padding;
+import com.gtnewhorizons.wdmla.impl.ui.sizer.Size;
+
+public class WorldBlockComponent extends Component {
+
+    public WorldBlockComponent(int blockX, int blockY, int blockZ) {
+        super(new Padding(), new Size(16, 16), new WorldBlockDrawable(blockX, blockY, blockZ));
+    }
+}

--- a/src/main/java/com/gtnewhorizons/wdmla/impl/ui/drawable/EntityDrawable.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/impl/ui/drawable/EntityDrawable.java
@@ -1,7 +1,9 @@
 package com.gtnewhorizons.wdmla.impl.ui.drawable;
 
+import com.gtnewhorizons.wdmla.overlay.GuiDraw;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.entity.RendererLivingEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.boss.BossStatus;
 
@@ -15,41 +17,53 @@ import mcp.mobius.waila.Waila;
 
 public class EntityDrawable implements IDrawable {
 
-    private final @NotNull EntityLiving entity;
+    private final @NotNull Entity entity;
 
-    public EntityDrawable(@NotNull EntityLiving entity) {
+    public EntityDrawable(@NotNull Entity entity) {
         this.entity = entity;
     }
 
     @Override
     public void draw(IArea area) {
-        String bossName = BossStatus.bossName;
-        int bossTimeout = BossStatus.statusBarTime;
-        boolean bossHasColorModifier = BossStatus.hasColorModifier;
-        float renderTagRange = RendererLivingEntity.NAME_TAG_RANGE;
-        float renderTagRangeSneaking = RendererLivingEntity.NAME_TAG_RANGE_SNEAK;
-        // editing entity custom name directly will trigger DataWatcher
-        RendererLivingEntity.NAME_TAG_RANGE = 0;
-        RendererLivingEntity.NAME_TAG_RANGE_SNEAK = 0;
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GL11.glEnable(GL11.GL_DEPTH_TEST);
+        // TODO: support float
         try {
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-            GL11.glEnable(GL11.GL_DEPTH_TEST);
-            // TODO: support float
-            GuiInventory.func_147046_a(
-                    (int) area.getX(),
-                    (int) (area.getY() + area.getH()),
-                    (int) area.getW(),
-                    135,
-                    0,
-                    entity);
+            if(entity instanceof EntityLiving living) {
+                String bossName = BossStatus.bossName;
+                int bossTimeout = BossStatus.statusBarTime;
+                boolean bossHasColorModifier = BossStatus.hasColorModifier;
+                float renderTagRange = RendererLivingEntity.NAME_TAG_RANGE;
+                float renderTagRangeSneaking = RendererLivingEntity.NAME_TAG_RANGE_SNEAK;
+                // editing entity custom name directly will trigger DataWatcher
+                RendererLivingEntity.NAME_TAG_RANGE = 0;
+                RendererLivingEntity.NAME_TAG_RANGE_SNEAK = 0;
+                GuiInventory.func_147046_a(
+                        (int) area.getX(),
+                        (int) (area.getY() + area.getH()),
+                        (int) area.getW(),
+                        135,
+                        0,
+                        living);
+                RendererLivingEntity.NAME_TAG_RANGE = renderTagRange;
+                RendererLivingEntity.NAME_TAG_RANGE_SNEAK = renderTagRangeSneaking;
+                BossStatus.bossName = bossName;
+                BossStatus.statusBarTime = bossTimeout;
+                BossStatus.hasColorModifier = bossHasColorModifier;
+            }
+            else {
+                GuiDraw.drawNonLivingEntity(
+                        (int) area.getX(),
+                        (int) (area.getY() + area.getH() - area.getW() / 2), //offset
+                        (int) area.getW(),
+                        135 + (entity.ticksExisted * 1) % 360,
+                        -0,
+                        entity
+                );
+            }
             GL11.glDisable(GL11.GL_DEPTH_TEST);
         } catch (Exception e) {
             Waila.log.error("Error rendering instance of entity", e);
         }
-        RendererLivingEntity.NAME_TAG_RANGE = renderTagRange;
-        RendererLivingEntity.NAME_TAG_RANGE_SNEAK = renderTagRangeSneaking;
-        BossStatus.bossName = bossName;
-        BossStatus.statusBarTime = bossTimeout;
-        BossStatus.hasColorModifier = bossHasColorModifier;
     }
 }

--- a/src/main/java/com/gtnewhorizons/wdmla/impl/ui/drawable/WorldBlockDrawable.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/impl/ui/drawable/WorldBlockDrawable.java
@@ -1,0 +1,39 @@
+package com.gtnewhorizons.wdmla.impl.ui.drawable;
+
+import blockrenderer6343.integration.wdmla.HUDBlockHandler;
+import com.gtnewhorizons.wdmla.api.ui.IDrawable;
+import com.gtnewhorizons.wdmla.api.ui.sizer.IArea;
+import mcp.mobius.waila.overlay.OverlayConfig;
+import net.minecraft.client.Minecraft;
+
+public class WorldBlockDrawable implements IDrawable {
+
+    private static final float SIZE_MULTIPLIER = 1.5f;
+
+    protected static float rotationPitch = 30f;
+    protected static long lastTime;
+
+    private final int blockX;
+    private final int blockY;
+    private final int blockZ;
+
+    public WorldBlockDrawable(int blockX, int blockY, int blockZ) {
+        this.blockX = blockX;
+        this.blockY = blockY;
+        this.blockZ = blockZ;
+    }
+
+    @Override
+    public void draw(IArea area) {
+        //TODO: get RenderPartialTick
+        rotationPitch += (Minecraft.getMinecraft().theWorld.getTotalWorldTime() - lastTime) * 1.0f;
+        //custom viewport is unaffected by GLScalef
+        HUDBlockHandler.drawWorldBlock(
+                (int) ((area.getX() - area.getW() * (SIZE_MULTIPLIER - 1)  / 2) * OverlayConfig.scale),
+                (int)((area.getY() - area.getH() * (SIZE_MULTIPLIER - 1)  / 2) * OverlayConfig.scale),
+                (int) (area.getW() * OverlayConfig.scale * SIZE_MULTIPLIER),
+                (int) (area.getH() * OverlayConfig.scale * SIZE_MULTIPLIER), blockX, blockY, blockZ,
+                30f, rotationPitch);
+        lastTime = Minecraft.getMinecraft().theWorld.getTotalWorldTime();
+    }
+}

--- a/src/main/java/com/gtnewhorizons/wdmla/overlay/GuiDraw.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/overlay/GuiDraw.java
@@ -3,10 +3,13 @@ package com.gtnewhorizons.wdmla.overlay;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.fluids.Fluid;
@@ -339,5 +342,27 @@ public final class GuiDraw {
         tessellator.addVertexWithUV(x1, y1, z, u1, v1);
         tessellator.addVertexWithUV(x1, y0, z, u1, v0);
         tessellator.addVertexWithUV(x0, y0, z, u0, v0);
+    }
+
+    //@see GuiInventory#func_147046_a
+    public static void drawNonLivingEntity(int x, int y, int size, float yaw, float pitch, Entity entity)
+    {
+        GL11.glEnable(GL11.GL_COLOR_MATERIAL);
+        GL11.glPushMatrix();
+        GL11.glTranslatef((float)x, (float)y, 50.0F);
+        GL11.glScalef((float)(-size), (float)size, (float)size);
+        GL11.glRotatef(180.0F, 0.0F, 0.0F, 1.0F);
+        GL11.glRotatef(180.0F - yaw, 0.0F, 1.0F, 0.0F);
+        GL11.glRotatef(-pitch, 1.0F, 0.0F, 1.0F);
+
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        RenderHelper.enableStandardItemLighting();
+
+        RenderManager.instance.playerViewY = 180.0F;
+        RenderManager.instance.renderEntityWithPosYaw(entity, 0.0D, 0.0D, 0.0D, 0.0F, 1.0F);
+
+        GL11.glPopMatrix();
+        RenderHelper.disableStandardItemLighting();
+        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
     }
 }

--- a/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultBlockInfoProvider.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultBlockInfoProvider.java
@@ -2,6 +2,8 @@ package com.gtnewhorizons.wdmla.plugin.core;
 
 import static mcp.mobius.waila.api.SpecialChars.*;
 
+import com.gtnewhorizons.wdmla.api.Mods;
+import com.gtnewhorizons.wdmla.impl.ui.component.WorldBlockComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -46,7 +48,14 @@ public enum DefaultBlockInfoProvider implements IBlockComponentProvider {
         ITooltip row = tooltip.horizontal();
         ItemStack itemStack = overrideStack != null ? overrideStack : accessor.getItemForm();
         if (PluginsConfig.core.defaultBlock.showIcon) {
-            row.child(new ItemComponent(itemStack).doDrawOverlay(false).tag(Identifiers.ITEM_ICON));
+            if (Mods.BLOCKRENDERER6343.isLoaded()) { //TODO:config
+                row.child(new WorldBlockComponent(
+                        accessor.getHitResult().blockX, accessor.getHitResult().blockY, accessor.getHitResult().blockZ)
+                        .tag(Identifiers.ITEM_ICON));
+            }
+            else {
+                row.child(new ItemComponent(itemStack).doDrawOverlay(false).tag(Identifiers.ITEM_ICON));
+            }
         }
 
         ITooltip row_vertical = row.vertical();

--- a/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultBlockInfoProvider.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultBlockInfoProvider.java
@@ -48,7 +48,7 @@ public enum DefaultBlockInfoProvider implements IBlockComponentProvider {
         ITooltip row = tooltip.horizontal();
         ItemStack itemStack = overrideStack != null ? overrideStack : accessor.getItemForm();
         if (PluginsConfig.core.defaultBlock.showIcon) {
-            if (Mods.BLOCKRENDERER6343.isLoaded()) { //TODO:config
+            if (Mods.BLOCKRENDERER6343.isLoaded() && PluginsConfig.core.defaultBlock.fancyRenderer) {
                 row.child(new WorldBlockComponent(
                         accessor.getHitResult().blockX, accessor.getHitResult().blockY, accessor.getHitResult().blockZ)
                         .tag(Identifiers.ITEM_ICON));

--- a/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultEntityInfoProvider.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultEntityInfoProvider.java
@@ -15,7 +15,6 @@ import com.gtnewhorizons.wdmla.config.General;
 import com.gtnewhorizons.wdmla.config.PluginsConfig;
 import com.gtnewhorizons.wdmla.impl.ui.ThemeHelper;
 import com.gtnewhorizons.wdmla.impl.ui.component.EntityComponent;
-import com.gtnewhorizons.wdmla.impl.ui.component.HPanelComponent;
 import com.gtnewhorizons.wdmla.impl.ui.component.TextComponent;
 import com.gtnewhorizons.wdmla.impl.ui.sizer.Padding;
 import com.gtnewhorizons.wdmla.impl.ui.sizer.Size;
@@ -46,13 +45,9 @@ public enum DefaultEntityInfoProvider implements IEntityComponentProvider {
     public void appendTooltip(ITooltip tooltip, EntityAccessor accessor) {
         ITooltip row = tooltip.horizontal();
         if (PluginsConfig.core.defaultEntity.showEntity) {
-            if (accessor.getEntity() instanceof EntityLiving living) {
-                row.child(
-                        new EntityComponent(living).padding(new Padding(6, 0, 10, 0)).size(new Size(12, 12))
-                                .tag(Identifiers.ENTITY));
-            } else {
-                row.child(new HPanelComponent().tag(Identifiers.ENTITY));
-            }
+            row.child(
+                    new EntityComponent(accessor.getEntity()).padding(new Padding(6, 0, 10, 0)).size(new Size(12, 12))
+                            .tag(Identifiers.ENTITY));
         }
 
         ITooltip row_vertical = row.vertical();

--- a/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultEntityInfoProvider.java
+++ b/src/main/java/com/gtnewhorizons/wdmla/plugin/core/DefaultEntityInfoProvider.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.wdmla.plugin.core;
 
 import static mcp.mobius.waila.api.SpecialChars.*;
 
+import com.gtnewhorizons.wdmla.impl.ui.component.HPanelComponent;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.ResourceLocation;
 
@@ -45,9 +46,15 @@ public enum DefaultEntityInfoProvider implements IEntityComponentProvider {
     public void appendTooltip(ITooltip tooltip, EntityAccessor accessor) {
         ITooltip row = tooltip.horizontal();
         if (PluginsConfig.core.defaultEntity.showEntity) {
-            row.child(
-                    new EntityComponent(accessor.getEntity()).padding(new Padding(6, 0, 10, 0)).size(new Size(12, 12))
-                            .tag(Identifiers.ENTITY));
+            if(!PluginsConfig.core.defaultEntity.fancyRenderer && !(accessor.getEntity() instanceof EntityLiving)) {
+                row.child(new HPanelComponent().tag(Identifiers.ENTITY));
+            }
+            else {
+                row.child(
+                        new EntityComponent(accessor.getEntity())
+                                .padding(new Padding(6, 0, 10, 0)).size(new Size(12, 12))
+                                .tag(Identifiers.ENTITY));
+            }
         }
 
         ITooltip row_vertical = row.vertical();

--- a/src/main/resources/assets/waila/lang/en_US.lang
+++ b/src/main/resources/assets/waila/lang/en_US.lang
@@ -297,6 +297,7 @@ option.wdmla.core.show.blockname=Show Block Name
 option.wdmla.core.show.modname=Show Mod Name
 option.wdmla.core.show.entity=Render Entity
 option.wdmla.core.show.entityname=Show Entity Name
+option.wdmla.core.fancy.renderer=Fancy Renderer
 
 # universal options
 option.wdmla.universal.normal.amount=Normal Amount


### PR DESCRIPTION
The next update will make WDMla tooltips respect the current block and entity state, instead of drawing fake inventory itemstack.
If you want to participate the test, please install following version of mods:

https://github.com/GTNewHorizons/WDMla/releases/tag/2.6.0-pre
https://github.com/GTNewHorizons/BlockRenderer6343/releases/tag/1.3.12-pre