### PR TITLE
Optionally group digits of RF energy storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ whitelist.json
 src/main/resources/mixins.*.json
 *.bat
 /src/doc/
+/libs/

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,4 +35,7 @@ dependencies {
 //    implementation('com.github.GTNewHorizons:GTNEIOrePlugin:1.3.0:dev') { transitive = false }
 //    implementation("com.github.GTNewHorizons:Avaritia:1.49:dev") { transitive = false }
 //    implementation("com.github.GTNewHorizons:ForestryMC:4.9.3:dev") { transitive = false }
+
+    // Deps for testing (TE) energy handles
+    //devOnlyNonPublishable(rfg.deobf(fileTree(dir: 'libs/', include: ['*.jar'])))
 }

--- a/src/main/java/mcp/mobius/waila/addons/thermalexpansion/HUDHandlerEnergyCell.java
+++ b/src/main/java/mcp/mobius/waila/addons/thermalexpansion/HUDHandlerEnergyCell.java
@@ -1,5 +1,6 @@
 package mcp.mobius.waila.addons.thermalexpansion;
 
+import java.text.DecimalFormat;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -14,6 +15,13 @@ import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.cbcore.LangUtil;
 
 public class HUDHandlerEnergyCell implements IWailaDataProvider {
+
+
+    private final DecimalFormat energyFormat;
+
+    public HUDHandlerEnergyCell() {
+        this.energyFormat = new DecimalFormat("###,###,###,###,###,###,###");
+    }
 
     @Override
     public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
@@ -33,14 +41,25 @@ public class HUDHandlerEnergyCell implements IWailaDataProvider {
 
         int energyReceive = accessor.getNBTInteger(accessor.getNBTData(), "Recv");
         int energySend = accessor.getNBTInteger(accessor.getNBTData(), "Send");
-
-        currenttip.add(
+        
+        if (!config.getConfig("thermalexpansion.digitgrouping")) {
+            currenttip.add(
                 String.format(
                         "%s/%s : %d / %d RF/t",
-                        LangUtil.translateG("hud.msg.in"),
-                        LangUtil.translateG("hud.msg.out"),
+                        LangUtil.translateG("hud.msg.input"),
+                        LangUtil.translateG("hud.msg.output"),
                         energyReceive,
                         energySend));
+        } else {
+            currenttip.add(
+                String.format(
+                        "%s/%s : %s / %s RF/t",
+                        LangUtil.translateG("hud.msg.input"),
+                        LangUtil.translateG("hud.msg.output"),
+                        energyFormat.format(energyReceive),
+                        energyFormat.format(energySend)));
+        }
+
 
         return currenttip;
     }

--- a/src/main/java/mcp/mobius/waila/addons/thermalexpansion/HUDHandlerIEnergyHandler.java
+++ b/src/main/java/mcp/mobius/waila/addons/thermalexpansion/HUDHandlerIEnergyHandler.java
@@ -1,5 +1,6 @@
 package mcp.mobius.waila.addons.thermalexpansion;
 
+import java.text.DecimalFormat;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -16,6 +17,12 @@ import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.utils.WailaExceptionHandler;
 
 public class HUDHandlerIEnergyHandler implements IWailaDataProvider {
+
+    private final DecimalFormat energyFormat;
+
+    public HUDHandlerIEnergyHandler() {
+        this.energyFormat = new DecimalFormat("###,###,###,###,###,###,###");
+    }
 
     @Override
     public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
@@ -39,12 +46,22 @@ public class HUDHandlerIEnergyHandler implements IWailaDataProvider {
         int maxEnergy = accessor.getNBTInteger(accessor.getNBTData(), "MaxStorage");
         try {
             if ((maxEnergy != 0) && (((ITaggedList) currenttip).getEntries("RFEnergyStorage").size() == 0)) {
-                ((ITaggedList) currenttip).add(String.format("%d / %d RF", energy, maxEnergy), "RFEnergyStorage");
+                if (!config.getConfig("thermalexpansion.digitgrouping")) {
+                    ((ITaggedList) currenttip).add(String.format("%d / %d RF", energy, maxEnergy), "RFEnergyStorage");
+                } else {
+                    ((ITaggedList) currenttip).add(
+                        String.format(
+                            "%s / %s RF", 
+                            energyFormat.format(energy), 
+                            energyFormat.format(maxEnergy)
+                        ), 
+                        "RFEnergyStorage");
+                }
             }
         } catch (Exception e) {
             currenttip = WailaExceptionHandler.handleErr(e, accessor.getTileEntity().getClass().getName(), currenttip);
         }
-
+        
         return currenttip;
     }
 

--- a/src/main/java/mcp/mobius/waila/addons/thermalexpansion/ThermalExpansionModule.java
+++ b/src/main/java/mcp/mobius/waila/addons/thermalexpansion/ThermalExpansionModule.java
@@ -67,6 +67,7 @@ public class ThermalExpansionModule {
             IEnergyInfo_getCurStorage = IEnergyInfo.getMethod("getInfoEnergyStored");
 
             ModuleRegistrar.instance().addConfigRemote("Thermal Expansion", "thermalexpansion.energyhandler");
+            ModuleRegistrar.instance().addConfigRemote("Thermal Expansion", "thermalexpansion.digitgrouping", false);
             ModuleRegistrar.instance().registerBodyProvider(new HUDHandlerIEnergyHandler(), IEnergyProvider);
             ModuleRegistrar.instance().registerNBTProvider(new HUDHandlerIEnergyHandler(), IEnergyProvider);
             ModuleRegistrar.instance().registerBodyProvider(new HUDHandlerIEnergyHandler(), IEnergyReceiver);


### PR DESCRIPTION
This PR implements the optional decimal formatting of RFEnergyStorage (HUDHandlerIEnergyHandler) and Energy Transfer (HUDHandlerEnergyCell) to enable digit grouping.
I've been using this back with Waila, and it has been a nice QOL Feature, enabling quicker reading.

In practice, it looks like this:
![Screenshot_388](https://github.com/user-attachments/assets/cba38fe7-16e3-440b-a13e-d2498193ef39)

Since some players probably find this change dubious, I've left it disabled by default for now.

In terms of locale, normally DecimalFormatSybols should pick up the correct separator by default, but I'm missing the knowledge there in how minecraft/forge provides the current locale to mods (Maybe we do it with language files?).